### PR TITLE
Explicitly include sphinxfeed.py in wheel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Run the test suite::
 
 Release a new version to PyPI::
 
-  $ python -m build
+  $ hatch build
   $ twine check --strict dist/*
   $ twine upload dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ path = "sphinxfeed.py"
 include = ["sphinxfeed.py"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["sphinxfeed"]
+only-include = ["sphinxfeed.py"]
 
 [tool.hatch.build]
 dev-mode-dirs = ["."]

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -4,7 +4,7 @@
 See https://github.com/lsaffre/sphinxfeed
 """
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 import os.path
 import time


### PR DESCRIPTION
With the following config:
```toml
[tool.hatch.build.targets.wheel]
packages = ["sphinxfeed"]
```
I think hatch is expecting a folder with something like:
```sh
sphinxfeed/
  ├── __init__.py
  └── sphinxfeed.py
```

This change tells hatch to get `sphinxfeed.py` from the root directory instead. I built and installed the wheel locally, and it seems to work as expected.