### PR TITLE
Add CI config to run tests, build, and publish to PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,39 @@
-name: Publish
+name: Test & Publish
 
 on:
   push:
+    branches: [master]
     tags: ['v*']
+  pull_request:
+    branches: [master]
 
 jobs:
+  # For all PRs and commits to main, run tests for each supported python version
+  # Note: This is currently expected to fail due to output variations based on
+  # dependency versions
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip setuptools
+          pip install -e .[dev]
+      - name: Run tests
+        run: pytest -v tests || diff tmp/ tests/docs1/expected && exit 1
+        # Remove this line once tests are updated to work in CI:
+        continue-on-error: true
+
+  # For git tags, build and publish package to PyPI
   publish:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -15,6 +43,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Build package distributions
-        run: hatch build
+        run: |
+          pip install hatch
+          hatch build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build package distributions
+        run: hatch build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,5 @@ Run the test suite::
 
 Release a new version to PyPI::
 
-  $ python -m build
-  $ twine check --strict dist/*
-  $ twine upload dist/*
-
-The ``twine upload`` step requires authentication credentials in your
-`~/.pypirc` file.
+  $ git tag v$(hatch version)
+  $ git push --tags

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ See also the files `LICENSE` and `CHANGELOG.rst`.
 Install a developer version::
 
   git clone https://github.com/lsaffre/sphinxfeed.git
-  pip install -e sphinxfeed
+  pip install -e ".[dev]"
 
 Run the test suite::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dynamic = ["version"]
 description = "Sphinx extension for generating RSS feeds"
 readme = "README.rst"
 license = {file = "LICENSE"}
+requires-python = ">= 3.8"
 
 authors = [
     { name = "Fergus Doyle", email = "fergus.doyle@largeblue.com" },
@@ -18,7 +19,6 @@ authors = [
 maintainers = [
     { name = "Luc Saffre", email = "luc@saffre-rumma.net" },
 ]
-
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -36,6 +36,13 @@ dependencies = [
     "feedgen",
     "python-dateutil",
     "Sphinx",
+]
+
+[project.optional-dependencies]
+dev = [
+    "atelier",
+    "hatch",
+    "pytest",
 ]
 
 [project.urls]


### PR DESCRIPTION
Here is some basic CI config using GitHub Actions. Let me know if you would like this to behave differently, or have any questions about how it works.

# Notes
* Tests will run for all supported python versions, triggered by PRs, tags, and commits to `master`.
    * These are currently expected to fail, but without blocking the build (using the  `continue-on-error` option). We can remove that once tests are updated to work in CI.
* Package will be built and published to PyPI on git tags.
    * Uses GitHub as a trusted publisher. This requires some setup on PyPI, under **Manage -> Publishing** ([Instructions here](https://docs.pypi.org/trusted-publishers/adding-a-publisher)).

# Alternative
In case you want to move this to GitLab CICD at some point, here is a roughly equivalent config (although I haven't tested it):

```yaml
image: python:3.12

stages:
  - test
  - publish

# TODO: build matrix for multiple python versions.
# This only runs tests for python 3.12.
# Docs: https://docs.gitlab.com/ee/ci/yaml/?query=matrix#parallelmatrix
test:
  stage: test
  script:
    - pip install -U pip setuptools
    - pip install -e .[dev]
    - pytest -v tests
    - diff tmp/ tests/docs1/expected

# This could be split into separate "build" and "publish" jobs if needed.
# Files can be passed between jobs using an "artifacts" config section:
# https://docs.gitlab.com/ee/ci/yaml/#artifacts
publish:
  stage: publish
  dependencies:
    - test
  only:
    - /^(v)?(\d+)(\.\d+)+?$/
  before_script:
    - apt update && apt install -y jq
    - pip install hatch twine id
  script:
    - hatch build
    # Use GitLab CI/CD as a trusted publisher to fetch a temporary PyPI token
    - oidc_token=$(python -m id PYPI)
    - resp=$(curl -X POST https://pypi.org/_/oidc/mint-token -d "{\"token\":\"${oidc_token}\"}")
    - api_token=$(jq --raw-output '.token' <<< "${resp}")
    - twine upload -u __token__ -p "${api_token}" python_pkg/dist/*
```