### PR TITLE
Add PyPI badges to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,15 @@
 ==========================
 The ``sphinxfeed`` package
 ==========================
+.. image:: https://img.shields.io/github/actions/workflow/status/lsaffre/sphinxfeed/build.yml
+  :alt: Build status
+  :target: https://github.com/lsaffre/sphinxfeed/actions
+.. image:: https://img.shields.io/pypi/v/sphinxfeed-lsaffre?color=blue
+  :alt: PyPI - package version
+  :target: https://pypi.org/project/sphinxfeed-lsaffre
+.. image:: https://img.shields.io/pypi/pyversions/sphinxfeed-lsaffre
+  :alt: PyPI - supported python versions
+  :target: https://pypi.org/project/sphinxfeed-lsaffre
 
 This Sphinx extension is a fork of Fergus Doyle's `sphinxfeed package
 <https://github.com/junkafarian/sphinxfeed>`__ which itself is derived from Dan
@@ -42,7 +51,7 @@ Features added
 Installation
 ============
 
-Soon you can install it using pip::
+You can install it using pip::
 
   pip install sphinxfeed-lsaffre
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Documentation",
     "Topic :: Utilities",
 ]

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -4,7 +4,7 @@
 See https://github.com/lsaffre/sphinxfeed
 """
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 import os.path
 import time


### PR DESCRIPTION
This adds some dynamic badges to the readme, made with [shields.io](https://shields.io). They show the following info:
* build status
* latest package version on PyPI
* supported python versions
  * This info is pulled from metadata on PyPI. Currently this is missing, but I added classifiers to inform PyPI which versions are supported.
  * That info will show up after the next release.

Currently it will look like this:
![image](https://github.com/user-attachments/assets/3df0f671-df56-4713-9b71-d0fca516b670)

And after the next release it will look like this (it may take a few minutes to update):
![image](https://github.com/user-attachments/assets/b2d26bfd-97eb-4e72-99b0-2c1f5843701e)