### PR TITLE
 Add `feed_entry_permalink` option to toggle setting `FeedEntry.guid`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,8 +30,14 @@ The sphinxfeed changelog
   logged at level INFO instead of WARNING because we don't want the
   ``sphinx-build -W`` to fail in this situation.
 
-- 20240720 : Removed dependency from ``atelier`` because it's easier to call 
+- 20240720 : Removed dependency from ``atelier`` because it's easier to call
   `subprocess.check_output()` directly here.
 
 - 20240722 : Support additional timestamp formats (any format supported by
   `dateutil <https://dateutil.readthedocs.io/en/stable/examples.html#parse-examples>`__)
+
+- 20240728: Add ``feed_entry_permalink`` option to set a permalink GUID for each
+  feed entry. If a `guid` value is found in the metadata, that will be used;
+  otherwise, a new one will be generated based on the entry URL.
+  Defaults to ``False``, in which case the entry URL will be used as a
+  non-permalink ID.  Applies to both Atom and RSS feeds.

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ Features added
   - ``use_dirhtml`` to specify whether `dirhtml` instead of `html` builder is
     used when calculating the url
 
+  - ``feed_entry_permalink`` to set a permalink GUID for each feed entry
+
   - ``feed_use_atom`` to generate an Atom feed instead of RSS
 
 

--- a/tests/outputs/rss.xml
+++ b/tests/outputs/rss.xml
@@ -13,6 +13,7 @@
         <item>
             <title>Second day</title>
             <link>http://news.example.com/second.html</link>
+            <guid>65a78116-5715-4f78-bbd4-384a018c99f9</guid>
             <description>
             &lt;section id="second-day"&gt;
             &lt;h1&gt;Second day&lt;a class="headerlink" href="#second-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;
@@ -28,6 +29,7 @@
         <item>
             <title>First day</title>
             <link>http://news.example.com/first.html</link>
+            <guid>f21329fa-c178-5550-9bbd-8cd2f591844a</guid>
             <description>
             &lt;section id="first-day"&gt;
             &lt;h1&gt;First day&lt;a class="headerlink" href="#first-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;

--- a/tests/sources/test-rss/conf.py
+++ b/tests/sources/test-rss/conf.py
@@ -16,4 +16,5 @@ feed_title = "Joe's blog"
 feed_field_name = 'date'
 feed_description = "Joe's blog"
 feed_filename = 'rss.xml'
+feed_entry_permalink = True
 feed_use_atom = False

--- a/tests/sources/test-rss/second.rst
+++ b/tests/sources/test-rss/second.rst
@@ -1,6 +1,7 @@
 :date: March 12 2018, 11:30 PM UTC
 :author: Joe
 :tags: poetry, unit-test
+:guid: 65a78116-5715-4f78-bbd4-384a018c99f9
 
 ==========
 Second day

--- a/tests/test_sphinxfeed.py
+++ b/tests/test_sphinxfeed.py
@@ -16,7 +16,6 @@ from sphinx.testing.util import SphinxTestApp
 
 from tests.conftest import OUTPUT_DIR
 
-RSS_ITEM_ATTRIBUTES = ["title", "link", "description", "pubDate"]
 RSS_META_ATTRIBUTES = [
     "copyright",
     "description",
@@ -25,6 +24,13 @@ RSS_META_ATTRIBUTES = [
     "language",
     "link",
     "title",
+]
+RSS_ITEM_ATTRIBUTES = [
+    "guid",
+    "title",
+    "link",
+    "description",
+    "pubDate",
 ]
 
 ATOM_SCHEMA = "http://www.w3.org/2005/Atom"


### PR DESCRIPTION
The use case for this is updating a feed entry that was previously published, and having feed readers recognize it as an updated version of the same entry (rather than a separate new entry). At least some feed readers rely on a GUID to uniquely identify a feed entry.

Changes:
* Add `feed_entry_permalink` option to set a [permalink GUID](https://python-feedgen.readthedocs.io/en/latest/api.entry.html#feedgen.entry.FeedEntry.guid) for each feed entry.
    * GUIDs are generated based on the entry URL.
    * Or if a `guid` value is found in page metadata, that will be used instead. For example, so it can be manually set if the URL changes.
    * Defaults to `False`, in which case the entry URL will be used as a non-permalink ID.
    * Applies to both Atom and RSS feeds.
* The only change in default behavior is that RSS feed items will now receive an ID (previously only for Atom feeds).

Let me know if you have any questions or suggestions.

Also, if/when this is merged, would you mind pushing another release to PyPI? Thank you!