### PR TITLE
Fix permalink id tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,3 +41,6 @@ The sphinxfeed changelog
   otherwise, a new one will be generated based on the entry URL.
   Defaults to ``False``, in which case the entry URL will be used as a
   non-permalink ID.  Applies to both Atom and RSS feeds.
+
+- 20260325: Add `urn:uuid:` prefix to permalink GUIDs so they validate as a full URL.
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,3 +44,4 @@ The sphinxfeed changelog
 
 - 20260325: Add `urn:uuid:` prefix to permalink GUIDs so they validate as a full URL.
 
+- 20260325: Handle trailing slashes in feed_base_url

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -96,7 +96,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     if app.config.feed_entry_permalink:
         if not (guid :=  metadata.get('guid')):
             guid = uuid5(NAMESPACE_URL, href)
-        item.guid(str(guid), permalink=True)
+        item.guid(f'urn:uuid:{guid}', permalink=True)
     # Entry ID option 2: Use the URL as the ID. Also sets item.guid (non-permalink) for RSS.
     else:
         item.id(href)

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -49,6 +49,8 @@ def create_feed_container(app):
     feed.link(href=app.config.feed_base_url)
     if app.config.feed_use_atom:
         feed.id(app.config.feed_base_url)
+        base_url = app.config.feed_base_url.rstrip('/')
+        feed.link(href=base_url + '/' + app.config.feed_filename, rel='self')
     feed.author({'name': app.config.feed_author})
     feed.description(app.config.feed_description)
 
@@ -85,7 +87,8 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
 
     item = FeedEntry()
     item.title(ctx.get('title'))
-    href = app.config.feed_base_url + '/' + ctx['current_page_name']
+    base_url = app.config.feed_base_url.rstrip('/')
+    href = base_url + '/' + ctx['current_page_name']
     if not app.config.use_dirhtml:
         href += ctx['file_suffix']
     item.link(href=href)
@@ -118,7 +121,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     env.feed_items[pagename] = item
 
     #Additionally, we might like to provide our templates with a way to link to the rss output file
-    ctx['rss_link'] = app.config.feed_base_url + '/' + app.config.feed_filename
+    ctx['rss_link'] = base_url + '/' + app.config.feed_filename
 
 
 def emit_feed(app, exc):

--- a/tests/outputs/atom-permalink.xml
+++ b/tests/outputs/atom-permalink.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
-    <id>http://news.example.com</id>
+    <id>http://news.example.com/</id>
     <title>First sphinxfeed tester</title>
     <updated>2024-07-21T18:58:02.430522+00:00</updated>
     <author>
         <name>Joe Dow</name>
     </author>
-    <link href="http://news.example.com"/>
+    <link href="http://news.example.com/"/>
     <generator uri="https://lkiesow.github.io/python-feedgen" version="1.0.0">python-feedgen</generator>
     <rights>2018 Joe Doe</rights>
     <subtitle>Joe's blog</subtitle>

--- a/tests/outputs/atom-permalink.xml
+++ b/tests/outputs/atom-permalink.xml
@@ -11,7 +11,7 @@
     <rights>2018 Joe Doe</rights>
     <subtitle>Joe's blog</subtitle>
     <entry>
-        <id>http://news.example.com/second</id>
+        <id>urn:uuid:ffc3948d-d699-5ad1-89b9-424f6c9a34aa</id>
         <title>Second day</title>
         <updated>2024-07-21T18:58:02.552860+00:00</updated>
         <author>
@@ -31,7 +31,7 @@
         <published>2018-03-12T23:30:00+00:00</published>
     </entry>
     <entry>
-        <id>http://news.example.com/first</id>
+        <id>urn:uuid:b76ad247-511f-5384-9d51-1a20a02ffd46</id>
         <title>First day</title>
         <updated>2024-07-21T18:58:02.488103+00:00</updated>
         <content>

--- a/tests/outputs/atom.xml
+++ b/tests/outputs/atom.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
-    <id>http://news.example.com</id>
+    <id>http://news.example.com/</id>
     <title>First sphinxfeed tester</title>
     <updated>2024-07-21T18:58:02.430522+00:00</updated>
     <author>
         <name>Joe Dow</name>
     </author>
-    <link href="http://news.example.com"/>
+    <link href="http://news.example.com/"/>
     <generator uri="https://lkiesow.github.io/python-feedgen" version="1.0.0">python-feedgen</generator>
     <rights>2018 Joe Doe</rights>
     <subtitle>Joe's blog</subtitle>

--- a/tests/outputs/atom.xml
+++ b/tests/outputs/atom.xml
@@ -11,7 +11,7 @@
     <rights>2018 Joe Doe</rights>
     <subtitle>Joe's blog</subtitle>
     <entry>
-        <id>http://news.example.com/second</id>
+        <id>urn:uuid:ffc3948d-d699-5ad1-89b9-424f6c9a34aa</id>
         <title>Second day</title>
         <updated>2024-07-21T18:58:02.552860+00:00</updated>
         <author>
@@ -31,7 +31,7 @@
         <published>2018-03-12T23:30:00+00:00</published>
     </entry>
     <entry>
-        <id>http://news.example.com/first</id>
+        <id>urn:uuid:b76ad247-511f-5384-9d51-1a20a02ffd46</id>
         <title>First day</title>
         <updated>2024-07-21T18:58:02.488103+00:00</updated>
         <content>

--- a/tests/outputs/rss-permalink.xml
+++ b/tests/outputs/rss-permalink.xml
@@ -13,6 +13,7 @@
         <item>
             <title>Second day</title>
             <link>http://news.example.com/second.html</link>
+            <guid isPermaLink="true">urn:uuid:65a78116-5715-4f78-bbd4-384a018c99f9</guid>
             <description>
             &lt;section id="second-day"&gt;
             &lt;h1&gt;Second day&lt;a class="headerlink" href="#second-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;
@@ -23,12 +24,12 @@
             Terese teisipäev,&lt;/p&gt;
             &lt;/section&gt;
             </description>
-            <guid isPermaLink="false">http://news.example.com/second.html</guid>
             <pubDate>Mon, 12 Mar 2018 23:30:00 +0000</pubDate>
         </item>
         <item>
             <title>First day</title>
             <link>http://news.example.com/first.html</link>
+            <guid isPermaLink="true">urn:uuid:f21329fa-c178-5550-9bbd-8cd2f591844a</guid>
             <description>
             &lt;section id="first-day"&gt;
             &lt;h1&gt;First day&lt;a class="headerlink" href="#first-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;
@@ -38,7 +39,6 @@
             Ikka Emma esmaspäev, …&lt;/p&gt;
             &lt;/section&gt;
             </description>
-            <guid isPermaLink="false">http://news.example.com/first.html</guid>
             <pubDate>Sun, 11 Mar 2018 00:00:00 +0000</pubDate>
         </item>
     </channel>

--- a/tests/outputs/rss-permalink.xml
+++ b/tests/outputs/rss-permalink.xml
@@ -3,7 +3,7 @@
     xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
     <channel>
         <title>First sphinxfeed tester</title>
-        <link>http://news.example.com</link>
+        <link>http://news.example.com/</link>
         <description>Joe's blog</description>
         <copyright>2018 Joe Doe</copyright>
         <docs>http://www.rssboard.org/rss-specification</docs>

--- a/tests/outputs/rss.xml
+++ b/tests/outputs/rss.xml
@@ -13,7 +13,7 @@
         <item>
             <title>Second day</title>
             <link>http://news.example.com/second.html</link>
-            <guid>65a78116-5715-4f78-bbd4-384a018c99f9</guid>
+            <guid>urn:uuid:65a78116-5715-4f78-bbd4-384a018c99f9</guid>
             <description>
             &lt;section id="second-day"&gt;
             &lt;h1&gt;Second day&lt;a class="headerlink" href="#second-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;
@@ -29,7 +29,7 @@
         <item>
             <title>First day</title>
             <link>http://news.example.com/first.html</link>
-            <guid>f21329fa-c178-5550-9bbd-8cd2f591844a</guid>
+            <guid>urn:uuid:f21329fa-c178-5550-9bbd-8cd2f591844a</guid>
             <description>
             &lt;section id="first-day"&gt;
             &lt;h1&gt;First day&lt;a class="headerlink" href="#first-day" title="Link to this heading"&gt;¶&lt;/a&gt;&lt;/h1&gt;

--- a/tests/outputs/rss.xml
+++ b/tests/outputs/rss.xml
@@ -3,7 +3,7 @@
     xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
     <channel>
         <title>First sphinxfeed tester</title>
-        <link>http://news.example.com</link>
+        <link>http://news.example.com/</link>
         <description>Joe's blog</description>
         <copyright>2018 Joe Doe</copyright>
         <docs>http://www.rssboard.org/rss-specification</docs>

--- a/tests/sources/test-atom/conf.py
+++ b/tests/sources/test-atom/conf.py
@@ -11,7 +11,7 @@ use_dirhtml = True
 
 # Sphinxfeed config
 extensions = ['sphinxfeed']
-feed_base_url = 'http://news.example.com'
+feed_base_url = 'http://news.example.com/'
 feed_author = 'Joe Dow'
 feed_title = "Joe's blog"
 feed_field_name = 'date'

--- a/tests/sources/test-atom/conf.py
+++ b/tests/sources/test-atom/conf.py
@@ -18,4 +18,3 @@ feed_field_name = 'date'
 feed_description = "Joe's blog"
 feed_filename = 'atom.xml'
 feed_use_atom = True
-feed_entry_permalink = True

--- a/tests/sources/test-atom/conf.py
+++ b/tests/sources/test-atom/conf.py
@@ -18,3 +18,4 @@ feed_field_name = 'date'
 feed_description = "Joe's blog"
 feed_filename = 'atom.xml'
 feed_use_atom = True
+feed_entry_permalink = True

--- a/tests/sources/test-rss/conf.py
+++ b/tests/sources/test-rss/conf.py
@@ -10,7 +10,7 @@ html_last_updated_fmt = '%Y-%m-%d'
 
 # Sphinxfeed config
 extensions = ['sphinxfeed']
-feed_base_url = 'http://news.example.com'
+feed_base_url = 'http://news.example.com/'
 feed_author = 'Joe Dow'
 feed_title = "Joe's blog"
 feed_field_name = 'date'

--- a/tests/sources/test-rss/conf.py
+++ b/tests/sources/test-rss/conf.py
@@ -16,5 +16,4 @@ feed_title = "Joe's blog"
 feed_field_name = 'date'
 feed_description = "Joe's blog"
 feed_filename = 'rss.xml'
-feed_entry_permalink = True
 feed_use_atom = False

--- a/tests/test_sphinxfeed.py
+++ b/tests/test_sphinxfeed.py
@@ -51,14 +51,19 @@ ATOM_ITEM_ATTRIBUTES = [
 ]
 
 
+@pytest.mark.parametrize(
+    "permalink,expected_file",
+    [(False, "rss.xml"), (True, "rss-permalink.xml")],
+)
 @pytest.mark.sphinx("html", testroot="rss")
 @patch("sphinxfeed.tzlocal", return_value=UTC)
-def test_build_rss(mock_tzlocal, app: SphinxTestApp, status: StringIO):
+def test_build_rss(mock_tzlocal, permalink: bool, expected_file: str, app: SphinxTestApp, status: StringIO):
+    app.config.feed_entry_permalink = permalink
     app.build(force_all=True)
     assert "build succeeded" in status.getvalue()
 
     build_dir = Path(app.srcdir) / "_build" / "html"
-    _compare_rss_feeds((build_dir / "rss.xml"), (OUTPUT_DIR / "rss.xml"))
+    _compare_rss_feeds((build_dir / "rss.xml"), (OUTPUT_DIR / expected_file))
 
 
 def _compare_rss_feeds(file_1: Path, file_2: Path):
@@ -79,14 +84,19 @@ def _compare_rss_feeds(file_1: Path, file_2: Path):
             _compare_attrs(attr, item_1, item_2)
 
 
+@pytest.mark.parametrize(
+    "permalink,expected_file",
+    [(False, "atom.xml"), (True, "atom-permalink.xml")],
+)
 @pytest.mark.sphinx("html", testroot="atom")
 @patch("sphinxfeed.tzlocal", return_value=UTC)
-def test_build_atom(mock_tzlocal, app: SphinxTestApp, status: StringIO):
+def test_build_atom(mock_tzlocal, permalink: bool, expected_file: str, app: SphinxTestApp, status: StringIO):
+    app.config.feed_entry_permalink = permalink
     app.build(force_all=True)
     assert "build succeeded" in status.getvalue()
 
     build_dir = Path(app.srcdir) / "_build" / "html"
-    _compare_atom_feeds((build_dir / "atom.xml"), (OUTPUT_DIR / "atom.xml"))
+    _compare_atom_feeds((build_dir / "atom.xml"), (OUTPUT_DIR / expected_file))
 
 
 def _compare_atom_feeds(file_1: Path, file_2: Path):


### PR DESCRIPTION
Updates #11.

I tested these changes with the w3 validator, and the related error ("id must be a full and valid URL") no longer appears. A small downside: since this changes IDs, feed readers that already picked up previously published posts will get duplicate entries for those posts.

* Add `urn:uuid:` prefix for `<id>`
* Remove duplicate slash if `feed_base_url` has a trailing slash (an unrelated issue I found while testing this) 
* Run tests with and without `feed_entry_permalink`
* Run CI tests for python 3.13 and 3.14
